### PR TITLE
Add github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/project_lead.md
+++ b/.github/ISSUE_TEMPLATE/project_lead.md
@@ -1,0 +1,12 @@
+---
+name: Project lead
+about: Request to be a project lead of an existing Jazzband project.
+title: 'Project Lead: <PACKAGE NAME>'
+labels: lead
+assignees: ''
+
+---
+
+# Project lead request
+
+Please explain why you'd fit the role of project lead for this project. Explain and prior involvement in the project. If there are existing project leads, they should also agree to this change.

--- a/.github/ISSUE_TEMPLATE/project_lead.md
+++ b/.github/ISSUE_TEMPLATE/project_lead.md
@@ -9,4 +9,4 @@ assignees: ''
 
 # Project lead request
 
-Please explain why you'd fit the role of project lead for this project. Explain and prior involvement in the project. If there are existing project leads, they should also agree to this change.
+Please explain why you'd fit the role of project lead for this project. Explain any prior involvement in the project. If there are existing project leads, they should also agree to this change.

--- a/.github/ISSUE_TEMPLATE/proposal.md
+++ b/.github/ISSUE_TEMPLATE/proposal.md
@@ -1,0 +1,37 @@
+---
+name: Proposal
+about: Create a proposal to move your package to Jazzband.
+title: 'Proposal: <PACKAGE NAME>'
+labels: proposal
+assignees: ''
+
+---
+
+# Project Proposal
+
+Please fill in the details below to confirm you adhere to the [Jazzband Guidelines](https://jazzband.co/about/guidelines), and also add the package name to the issue title.
+
+## Project Details:
+Enter your project name here.
+
+## Project Description
+Briefly describe your project, and your reasons for requesting a transfer here.
+
+## Project Leads:
+Please list anyone who you would like to be made a project lead.
+
+## Confirmation of Guidelines
+
+Please confirm the following:
+
+- [ ] I am the project owner, or have permission from the project owner, to request a transfer.
+
+- [ ] This project is a [viable candidate](https://jazzband.co/about/guidelines#viability) for JazzBand.
+
+- [ ] This project fulfills the [documentation requirements](https://jazzband.co/about/guidelines#documentation).
+
+- [ ] This project is [tested](https://jazzband.co/about/guidelines#tests).
+
+- [ ] I am happy to adopt Jazzband's [code of conduct](https://jazzband.co/about/guidelines#conduct) in this project.
+
+- [ ] I am happy to include Jazzband's [contributing guidelines](https://jazzband.co/about/guidelines#contributing-guidelines) in this project.

--- a/.github/ISSUE_TEMPLATE/proposal.md
+++ b/.github/ISSUE_TEMPLATE/proposal.md
@@ -11,13 +11,13 @@ assignees: ''
 
 Please fill in the details below to confirm you adhere to the [Jazzband Guidelines](https://jazzband.co/about/guidelines), and also add the package name to the issue title.
 
-## Project Details:
+## Project Details
 Enter your project name here.
 
 ## Project Description
 Briefly describe your project, and your reasons for requesting a transfer here.
 
-## Project Leads:
+## Project Leads
 Please list anyone who you would like to be made a project lead.
 
 ## Confirmation of Guidelines
@@ -26,7 +26,7 @@ Please confirm the following:
 
 - [ ] I am the project owner, or have permission from the project owner, to request a transfer.
 
-- [ ] This project is a [viable candidate](https://jazzband.co/about/guidelines#viability) for JazzBand.
+- [ ] This project is a [viable candidate](https://jazzband.co/about/guidelines#viability) for Jazzband.
 
 - [ ] This project fulfills the [documentation requirements](https://jazzband.co/about/guidelines#documentation).
 

--- a/.github/ISSUE_TEMPLATE/pypi_release.md
+++ b/.github/ISSUE_TEMPLATE/pypi_release.md
@@ -8,6 +8,6 @@ assignees: ''
 ---
 
 # PyPI Release
-Please read the information about [releases](https://jazzband.co/about/releases) on the website before submitting an issue. In particular, if a project already has project leads assigned, then you'd be better of creating an issue in the individual project, and asking the leads to do a release.
+Please read the information about [releases](https://jazzband.co/about/releases) on the website before submitting an issue. In particular, if a project already has project leads assigned, then you'd be better off creating an issue in the individual project, and asking the leads to do a release.
 
 In the event there are no project leads, you're in the right place! Please link the project for which you'd like to create a release.

--- a/.github/ISSUE_TEMPLATE/pypi_release.md
+++ b/.github/ISSUE_TEMPLATE/pypi_release.md
@@ -1,0 +1,13 @@
+---
+name: PyPI Release
+about: Request a new release of a project to PyPI.
+title: 'PyPI Release: <PACKAGE NAME>'
+labels: pypi
+assignees: ''
+
+---
+
+# PyPI Release
+Please read the information about [releases](https://jazzband.co/about/releases) on the website before submitting an issue. In particular, if a project already has project leads assigned, then you'd be better of creating an issue in the individual project, and asking the leads to do a release.
+
+In the event there are no project leads, you're in the right place! Please link the project for which you'd like to create a release.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,8 @@
+---
+name: Question
+about: Anything else.
+title: ''
+labels: question
+assignees: ''
+
+---


### PR DESCRIPTION
Closes #124.

This change causes anyone creating a new issue to be faced with choices. You can see an example of how this looks [here](https://github.com/jstockwin/py-pdf-parser/issues/new/choose).This might be a fairly heavy-weight solution, but it IMO it keeps things nice and explicit.

I've gone for:
- Proposal
- Project Lead
- PyPI Release
- Question

Each of these should automatically add the required labels (note: currently there is no `proposal` label, do we want to add one?).

This should also help with (if not close) #188. (I'm pretty sure it will add the labels now, even though non-contributors won't be able to edit them, but we'll have to check).

We may want to update the wording on the website after this, as all of the issue links should probably just go to the issue template choice page, and we'll tell them which one to click on?

Regarding the actual content of the templates, you'll probably have some suggested changes since I'm not really familiar with all of the processes involved. The proposal one maybe seems a bit too formal (we don't want to scare people off!), however I do like the simplicity that a list of checkboxes provides.. what do you think?

(small side note: I was initially surprised that I couldn't push directly to this repo, but I guess that makes sense since it's `jazzband-roadies` not `jazzband`. I guess not an issue since this repo won't be changed much?)